### PR TITLE
Show application header

### DIFF
--- a/frontend/style.css
+++ b/frontend/style.css
@@ -102,9 +102,16 @@ body {
   padding: 0;
 }
 
-/* Header - Hidden */
+/* Header */
 header {
-  display: none;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  padding: 1.25rem 2rem;
+  background: var(--surface);
+  border-bottom: 1px solid var(--border-color);
+  flex-shrink: 0;
+  text-align: center;
 }
 
 header h1 {


### PR DESCRIPTION
Make the header visible by replacing `display: none` with proper flex styling and a border-bottom separator in `frontend/style.css`.

Closes #2

Generated with [Claude Code](https://claude.ai/code)